### PR TITLE
gallery-resurrect breaks archive.php autodownloading

### DIFF
--- a/targets/gallery-resurrect.json
+++ b/targets/gallery-resurrect.json
@@ -27,6 +27,10 @@
 			"https://exhentai.org/*",
 			"https://e-hentai.org/*"
 		],
+		"exclude": [
+			"https://exhentai.org/archiver.php*",
+			"https://e-hentai.org/archiver.php*"
+		],
 		"icon": {
 			"value": "../images/icon-48.png",
 			"transform": "toDataUrl"


### PR DESCRIPTION
When the archiver settings in uconfig.php are set to auto start, it inserts a call to change `document.location` via the same `setTimeout(gotonext(), 1)` call that fjords do.

This PR excludes archiver.php from the allowed list of pages, since it doesn't need to run on there.